### PR TITLE
Add missing ; to fix syntax issue

### DIFF
--- a/resources/views/dockerfile.blade.php
+++ b/resources/views/dockerfile.blade.php
@@ -19,7 +19,7 @@ RUN composer install --optimize-autoloader --no-dev \
     && chown -R www-data:www-data /var/www/html \
     && sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php \
     && echo "MAILTO=\"\"\n* * * * * www-data /usr/bin/php /var/www/html/artisan schedule:run" > /etc/cron.d/laravel; \
-    if [ -d .fly ]; then cp .fly/entrypoint.sh /entrypoint; chmod +x /entrypoint fi;
+    if [ -d .fly ]; then cp .fly/entrypoint.sh /entrypoint; chmod +x /entrypoint; fi;
 
 @if(in_array($octane, ['frankenphp', 'roadrunner', 'swoole']))
 @include('octane-'.$octane)


### PR DESCRIPTION
Closes #4 

**What:**
This adds a missing ";" in the Dockerfile template. 

**Why:**
It is needed to successfully build an image from the Dockerfile generated

