### PR TITLE
Update view cache path, build changes

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -4,7 +4,8 @@ return [
     'paths' => [
         resource_path('views'),
     ],
-   'compiled' => \Phar::running()
-       ? getcwd().'/storage/framework/views'
-       : env('VIEW_COMPILED_PATH', realpath(storage_path('framework/views'))),
+    'compiled' => env(
+        'VIEW_COMPILED_PATH',
+        sys_get_temp_dir().'/dockerfile-laravel-view', // Please rm -r '/tmp/dockerfile-laravel-view' to delete cached views
+    )
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -4,9 +4,7 @@ return [
     'paths' => [
         resource_path('views'),
     ],
-
-    'compiled' => env(
-        'VIEW_COMPILED_PATH',
-        sys_get_temp_dir(), //realpath(storage_path('framework/views'))
-    ),
+   'compiled' => \Phar::running()
+       ? getcwd().'/storage/framework/views'
+       : env('VIEW_COMPILED_PATH', realpath(storage_path('framework/views'))),
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -6,6 +6,6 @@ return [
     ],
     'compiled' => env(
         'VIEW_COMPILED_PATH',
-        sys_get_temp_dir().'/dockerfile-laravel-view', // Please rm -r '/tmp/dockerfile-laravel-view' to delete cached views
+        getcwd().'/storage/framework/views'  // OR: sys_get_temp_dir().'/dockerfile-laravel-view'
     )
 ];

--- a/resources/views/dockerfile.blade.php
+++ b/resources/views/dockerfile.blade.php
@@ -19,7 +19,7 @@ RUN composer install --optimize-autoloader --no-dev \
     && chown -R www-data:www-data /var/www/html \
     && sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php \
     && echo "MAILTO=\"\"\n* * * * * www-data /usr/bin/php /var/www/html/artisan schedule:run" > /etc/cron.d/laravel; \
-    if [ -d .fly ]; then cp .fly/entrypoint.sh /entrypoint; chmod +x /entrypoint fi;
+    if [ -d .fly ]; then cp .fly/entrypoint.sh /entrypoint; chmod +x /entrypoint; fi;
 
 @if(in_array($octane, ['frankenphp', 'roadrunner', 'swoole']))
 @include('octane-'.$octane)

--- a/resources/views/dockerfile.blade.php
+++ b/resources/views/dockerfile.blade.php
@@ -19,7 +19,7 @@ RUN composer install --optimize-autoloader --no-dev \
     && chown -R www-data:www-data /var/www/html \
     && sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php \
     && echo "MAILTO=\"\"\n* * * * * www-data /usr/bin/php /var/www/html/artisan schedule:run" > /etc/cron.d/laravel; \
-    if [ -d .fly ]; then cp .fly/entrypoint.sh /entrypoint; chmod +x /entrypoint; fi;
+    if [ -d .fly ]; then cp .fly/entrypoint.sh /entrypoint; chmod +x /entrypoint fi;
 
 @if(in_array($octane, ['frankenphp', 'roadrunner', 'swoole']))
 @include('octane-'.$octane)


### PR DESCRIPTION
Closes #6 

**What:**
This updates the default view cache path to storage/frameworks/views. 

**Why:**
Issue #6 - changes in views not reflected in a newly built version of the application, because the build looks at the cached views and not the latest view when building the application. The change in this PR allows cached views to be saved in a space that is readily viewable, and deletable, and when deleted, allows changes to views be reflected in new builds.

View changes are important to be reflected in new builds of the application, because the Dockerfile template is a view. And it is this template that is used by this project to generate a Dockerfile