### PR TITLE
Don't include the .env file in fly/dockerignore generated if not deploying to prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ And that should generate a Dockerfile at the current directory the command was r
   * `--no-assets` - Skip compiling static assets
   * `--force` - Overwrite existing files
   * `--skip` - Keep existing files
+  * `--dev` - Include dev dependencies in the creation of the image, i.e. the local .env file
 
 The dockerfile generator accepts the following options:
 

--- a/app/Commands/GenerateCommand.php
+++ b/app/Commands/GenerateCommand.php
@@ -17,7 +17,7 @@ class GenerateCommand extends Command
                             {--no-assets : Skip compiling static assets}
                             {--force : Overwrite existing files}
                             {--skip : Keep existing files}
-                            {--prod : Ready for deployment to production}';
+                            {--dev : Include dev dependencies like the local .env file}';
 
     /**
      * The description of the command.
@@ -46,8 +46,8 @@ class GenerateCommand extends Command
         $options = [
             'octane' => $this->option('octane'),
             'build_assets' => ! $this->option('no-assets'),
+            'dev' => $this->option('dev'),
             'laravel_version' => (new \App\Services\Scanner())->laravelVersion(),
-            'production_ready' => ($this->option('prod')? $this->option('prod') : false)
         ];
         
         // Define the list of templates to render.

--- a/app/Commands/GenerateCommand.php
+++ b/app/Commands/GenerateCommand.php
@@ -15,8 +15,9 @@ class GenerateCommand extends Command
     protected $signature = 'generate
                             {--o|octane= : If using Octane, provide which flavor - one of: roadrunner, swoole, frankenphp}
                             {--no-assets : Skip compiling static assets}
-                            {--force : overwrite existing files}
-                            {--skip : keep existing files}';
+                            {--force : Overwrite existing files}
+                            {--skip : Keep existing files}
+                            {--prod : Ready for deployment to production}';
 
     /**
      * The description of the command.
@@ -45,7 +46,8 @@ class GenerateCommand extends Command
         $options = [
             'octane' => $this->option('octane'),
             'build_assets' => ! $this->option('no-assets'),
-            'laravel_version' => (new \App\Services\Scanner())->laravelVersion()
+            'laravel_version' => (new \App\Services\Scanner())->laravelVersion(),
+            'production_ready' => ($this->option('prod')? $this->option('prod') : false)
         ];
         
         // Define the list of templates to render.

--- a/resources/views/fly/dockerignore.blade.php
+++ b/resources/views/fly/dockerignore.blade.php
@@ -7,7 +7,7 @@ storage/framework/cache/*
 storage/framework/sessions/*
 storage/framework/views/*
 storage/logs/*
-@if($production_ready)
+@if( !$dev )
 *.env*
 @endif
 .rr.yml

--- a/resources/views/fly/dockerignore.blade.php
+++ b/resources/views/fly/dockerignore.blade.php
@@ -7,7 +7,9 @@ storage/framework/cache/*
 storage/framework/sessions/*
 storage/framework/views/*
 storage/logs/*
+@if($production_ready)
 *.env*
+@endif
 .rr.yml
 rr
 frankenphp


### PR DESCRIPTION
**What:**
Don't include the .env file in the files to ignore in the generated .dockerignore file from .fly/dockerignore template when creating for a local docker container.

**How:**
Create a --prod flag. Passing this flag to the command will let the command know that it is going to create a docker image for a production app, and therefore not include the .env file located in the current projet.

Update the .dockerignore template with an @if condition that only adds the .env file to the list of files to ignore when the --prod flag is not passed.

**Why:**
The existing fly/dockerignore template is geared towards a possible deployment to Fly.io. However, the .env file is included in the list of files to ignore here. This .env file is required for a working file for local runs of a containerized laravel application.