### PR TITLE
Remove asset build stage when no package.json exists

### DIFF
--- a/app/Commands/GenerateCommand.php
+++ b/app/Commands/GenerateCommand.php
@@ -49,7 +49,7 @@ class GenerateCommand extends Command
 
         // Define the options available to the templates.
         $options = [
-            'build_assets' => ! $this->option('no-assets'),
+            'build_assets' => $scan->shouldBuildAssets( $this->options() ),
             'dev' => $this->option('dev'),
             'laravel_version' => $scan->laravelVersion( $this->options() ),
             'fly' => $scan->isForFly(),
@@ -57,6 +57,7 @@ class GenerateCommand extends Command
             'filament' => $scan->filamentVersion( $this->options() ),
             'frankenphp_binary' => $this->option('frankenphp-binary')
         ];   
+
 
         // Define the list of templates to render.
         // The key is the template name, and the value is the output file name.

--- a/app/Services/File.php
+++ b/app/Services/File.php
@@ -26,6 +26,20 @@ class File
         return file_put_contents($output, implode("\n", $result) . "\n");
     }
 
+    /**
+     * Check if package.json exists in the directory
+     */
+    public function packageJsonExists( $directory )
+    {
+        $path = $directory.'/package.json';
+
+        if( file_exists( $path ) ) 
+            return true;
+        else{
+            return false;
+        }
+    }
+
     public function composerJsonContent( $directory )
     {
         $path = $directory.'/composer.json';

--- a/app/Services/Scanner.php
+++ b/app/Services/Scanner.php
@@ -82,6 +82,23 @@ class Scanner
             return false;
     }
 
+    /**
+     * Determines whether to build assets or not
+     */
+    public function shouldBuildAssets( array $options )
+    {
+        $shouldBuild = !$options['no-assets'];
+        $packageJsonExists = (new \App\Services\File())->packageJsonExists( $options['path'] );
+
+        if( $shouldBuild && $packageJsonExists ) {
+            // If want to build assets, make sure package.json exists
+            return true;
+        }else{
+            // Otherwise don't build
+            return false;
+        }
+    }
+
 
     /**
      * Lists templates to generate based on options passed

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -2,7 +2,7 @@
 
 function ignoreFiles( )
 {
-    return ['composer.json','frankenphp','rr','.rr.yaml'];
+    return ['composer.json','frankenphp','rr','.rr.yaml','package.json'];
 }
 
 /**
@@ -69,6 +69,8 @@ it('generates proper templates for each supported base', function ( )
     $directories = \File::directories( 'tests/Feature/Supported' );   
     foreach($directories as $dir) {
         #if( $dir != "tests/Feature/Supported/10_base" ) continue;//-- revise and uncomment this line if you want to test out a specific Support subfolder
+        // package.json is needed to generate a Dockerfile with asset build stage, will be deleted in second test below
+        file_put_contents( $dir.'/package.json','{}' );
 
         // Generate Dockerfile, by scanning contents of files in the current directory, set through --path
         // FIRST assert: command successfully runs and exits
@@ -186,6 +188,9 @@ it('generates templates with proper snippets', function ()
                 $fh->deleteDir('tests/Feature/Combination');
             }
         } 
+
+        // Delete the generated package.json file from "generates proper templates for each supported base"
+        unlink( $base.'/package.json' );
     }    
 });
 


### PR DESCRIPTION
**What and Why:**
Remove the asset build stage from the generated Dockerfile when package.json does not exist. This build stage results in build error for Laravel apps that don't use package.json, i.e. api apps. See community member [issue here!](https://community.fly.io/t/failed-to-fly-launch-laravel-project/20000/3)

**How:**
Set the value of option['build-asset'] to false if no package.json exists!

**Also:**
Quick edit to the GenerateCommandTest.php to include package.json file in each supported test folder, so that the asset build stage is included in the generated dockerfiles during testing.